### PR TITLE
Use right parent entry name

### DIFF
--- a/_includes/page-date.html
+++ b/_includes/page-date.html
@@ -1,4 +1,4 @@
 <time class="page-date dt-published" datetime="{{ page.date | date_to_xmlschema }}">
   {%- assign date_format = site.date_format | default: "%B %-d, %Y" -%}
-  <a class="u-url" href="{{ entry.url | relative_url }}">{{ page.date | date: date_format }}</a>
+  <a class="u-url" href="{{ page.url | relative_url }}">{{ page.date | date: date_format }}</a>
 </time>


### PR DESCRIPTION
This is a bug fix.

## Summary
Use correct parent entry name. This looks like a copy paste error. htmlproofer complains about empty links otherwise.
